### PR TITLE
Adds Keybind to open menu

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -42,6 +42,7 @@ class CfgFunctions
         {
             file = "AcreRadioManager\functions\core";
             class openRadioSettings {}; // Opens the main dialog
+            class initKeybinds { preInit = 1; };  // Keybind init
         };
         // ===== Actions / User Interactions =====
         class actions

--- a/functions/core/fn_initKeybinds.sqf
+++ b/functions/core/fn_initKeybinds.sqf
@@ -1,0 +1,13 @@
+#include "\a3\ui_f\hpp\defineDIKCodes.inc"
+
+[
+    "ACRE Radio Manager", 
+    "Open_Menu_Key", 
+    "Open Menu", 
+    {
+        [] call AcreRadioManager_fnc_openRadioSettings;
+        true
+    }, 
+    "", 
+    [DIK_C, [false, true, true]]
+] call CBA_fnc_addKeybind;


### PR DESCRIPTION
Simple PR that adds a CBA keybind to open menu

Resolves [issue #7](https://github.com/Eludage/acre-radio-manager/issues/7)
default key: control + alt + c

feel free to modify/change locations
I tested it and it seems okay
![202709~1](https://github.com/user-attachments/assets/0bce1587-03f2-41cc-ad5c-92816c6c7898)
